### PR TITLE
base-files: rc.common: show supplied EXTRA_HELP

### DIFF
--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -109,7 +109,7 @@ ${INIT_TRACE:+set -x}
 	EXTRA_HELP="\
 	running	Check if service is running
 	status	Service status
-	"
+${EXTRA_HELP}"
 
 	. $IPKG_INSTROOT/lib/functions/procd.sh
 	basescript=$(readlink "$initscript")


### PR DESCRIPTION
If packages USE_PROCD, then append the EXTRA_HELP, which the packages can supply, instead of replacing it.
